### PR TITLE
Add docker environment information to the top line

### DIFF
--- a/oh-my-posh/README.md
+++ b/oh-my-posh/README.md
@@ -15,6 +15,7 @@ A detailed Oh My Posh theme that provides system and environment information in 
 - 🔋 Battery status indicator
 - ⏱️ Command execution time
 - 🐍 Python environment indicator
+- 🐳 Docker environment information
 
 ## 🎨 Style
 

--- a/oh-my-posh/plenty-of-info.omp.json
+++ b/oh-my-posh/plenty-of-info.omp.json
@@ -94,6 +94,15 @@
           "template": " \ue73c {{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }} "
         },
         {
+          "type": "docker",
+          "style": "diamond",
+          "background": "#FEF5ED",
+          "foreground": "#011627",
+          "leading_diamond": "\ue0b2",
+          "trailing_diamond": "<transparent,#FEF5ED>\ue0b2</>",
+          "template": "{{ if .Context }} \uf308 {{ .Context }} {{ end }}"
+        },
+        {
           "background": "#FEF5ED",
           "foreground": "#011627",
           "leading_diamond": "\ue0b2",


### PR DESCRIPTION
Fixes #6

Add docker environment information to the top line in the same visual format as the python venv.

* Add a new segment for docker environment information in `oh-my-posh/plenty-of-info.omp.json`.
  * Use the same diamond style, foreground, and background colors as the python venv segment.
  * Set the template for the docker segment to `\uf308 {{ .Context }}`.
  * Make the docker information conditional on the value being present.
