### PR TITLE
Add sleep and mklink functions to PowerShell profile

### DIFF
--- a/powershell-profile/README.md
+++ b/powershell-profile/README.md
@@ -17,6 +17,8 @@ This guide will help you set up your PowerShell profile to import a custom profi
 - 🔑 Elevated privileges helper (sudo)
 - 🌍 Environment variable management
 - ⚡ Performance optimizations
+- 💤 Sleep function to pause execution
+- 🔗 Mklink function to create symbolic links
 
 ## 🔍 Requirements
 
@@ -95,7 +97,7 @@ This guide will help you set up your PowerShell profile to import a custom profi
 | `posh-git` | Posh-Git integration |
 | `oh-my-posh` | Oh My Posh theme support |
 | `$PROFILE` | Path to the current profile script |
-
-
+| `sleep` | Pauses execution for a specified number of seconds |
+| `mklink` | Creates symbolic links |
 
 For more information, refer to the main repository [here](../README.md).

--- a/powershell-profile/profile.ps1
+++ b/powershell-profile/profile.ps1
@@ -50,3 +50,17 @@ function pull-profile {
 function sudo {
     Start-Process -verb RunAs wt
 }
+
+# sleep function to pause execution for a specified number of seconds
+function sleep {
+    param (
+        [int]$seconds
+    )
+    
+    Start-Sleep -Seconds $seconds
+}
+
+# mklink function to create symbolic links
+function mklink { 
+    cmd /c mklink $args 
+}


### PR DESCRIPTION
Fixes #12

Add `sleep` and `mklink` functions to `powershell-profile/profile.ps1`.

* Add `sleep` function to pause execution for a specified number of seconds.
* Add `mklink` function to create symbolic links.
* Update `README.md` to mention the new `sleep` and `mklink` functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ScottWilliamAnderson/scripts/pull/13?shareId=8211ccec-3b11-4778-9fad-3a60eb79a323).