### PR TITLE
Add .vscode folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Exclude files specific to my machine
 /ForceConnectWifi/*.bat
+
+# Ignore .vscode folder
+.vscode/


### PR DESCRIPTION
Fixes #14

Add `.vscode` folder to `.gitignore` file

* Add `.vscode/` to the list of ignored files and directories in `.gitignore`
* Retain existing entries in `.gitignore` file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ScottWilliamAnderson/scripts/pull/15?shareId=6bb8108a-ac32-4e7f-a716-5a9a4cc8780d).