### PR TITLE
Measure performance/time for each part of PowerShell profile

### DIFF
--- a/powershell-profile/README.md
+++ b/powershell-profile/README.md
@@ -19,6 +19,7 @@ This guide will help you set up your PowerShell profile to import a custom profi
 - ⚡ Performance optimizations
 - 💤 Sleep function to pause execution
 - 🔗 Mklink function to create symbolic links
+- ⏱️ Timing and logging for performance measurement
 
 ## 🔍 Requirements
 
@@ -99,5 +100,9 @@ This guide will help you set up your PowerShell profile to import a custom profi
 | `$PROFILE` | Path to the current profile script |
 | `sleep` | Pauses execution for a specified number of seconds |
 | `mklink` | Creates symbolic links |
+
+## ⏱️ Timing and Logging
+
+The profile script now includes timing and logging functionality to measure the performance of each section. Timing information is logged to a file named `profile_timing.log` in the `powershell-profile` directory. The log file records the start time, end time, and duration for each section of the profile script.
 
 For more information, refer to the main repository [here](../README.md).

--- a/powershell-profile/README.md
+++ b/powershell-profile/README.md
@@ -105,4 +105,8 @@ This guide will help you set up your PowerShell profile to import a custom profi
 
 The profile script now includes timing and logging functionality to measure the performance of each section. Timing information is logged to a file named `profile_timing.log` in the `powershell-profile` directory. The log file records the start time, end time, and duration for each section of the profile script.
 
+## 📝 Optional Logging
+
+Logging is optional and controlled by the `ENABLE_PROFILE_LOGGING` environment variable. By default, logging is disabled. To enable logging, set the `ENABLE_PROFILE_LOGGING` environment variable to `true`.
+
 For more information, refer to the main repository [here](../README.md).

--- a/powershell-profile/profile.ps1
+++ b/powershell-profile/profile.ps1
@@ -20,33 +20,29 @@ if (-not $env:USERPROFILE) {
     return
 }
 
-# Timing for Chocolatey profile import
-$chocoStartTime = Get-Date
-# Import chocolatey profile so it can run refreshenv command
-Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-$chocoEndTime = Get-Date
-Log-Timing -section "Chocolatey Profile Import" -startTime $chocoStartTime -endTime $chocoEndTime
+# Check if logging is enabled
+$enableLogging = $false
+if ($env:ENABLE_PROFILE_LOGGING -eq "true") {
+    $enableLogging = $true
+}
 
-# Timing for environment variables refresh
-$envStartTime = Get-Date
-# Refresh environment variables
-refreshenv
-$envEndTime = Get-Date
-Log-Timing -section "Environment Variables Refresh" -startTime $envStartTime -endTime $envEndTime
+# List of commands to run and their descriptions
+$commands = @(
+    @{ Command = { Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1 }; Description = "Chocolatey Profile Import" },
+    @{ Command = { refreshenv }; Description = "Environment Variables Refresh" },
+    @{ Command = { Import-Module posh-git }; Description = "Posh-Git Import" },
+    @{ Command = { oh-my-posh init pwsh --config "$repoPath\oh-my-posh\plenty-of-info.omp.json" | Invoke-Expression }; Description = "Oh-My-Posh Theme Import" }
+)
 
-# Timing for posh-git import
-$poshGitStartTime = Get-Date
-# Import posh-git
-Import-Module posh-git
-$poshGitEndTime = Get-Date
-Log-Timing -section "Posh-Git Import" -startTime $poshGitStartTime -endTime $poshGitEndTime
-
-# Timing for oh-my-posh theme import
-$ompStartTime = Get-Date
-# Import oh-my-posh theme
-oh-my-posh init pwsh --config "$repoPath\oh-my-posh\plenty-of-info.omp.json" | Invoke-Expression
-$ompEndTime = Get-Date
-Log-Timing -section "Oh-My-Posh Theme Import" -startTime $ompStartTime -endTime $ompEndTime
+# Run each command and log timing if enabled
+foreach ($cmd in $commands) {
+    $startTime = Get-Date
+    & $cmd.Command
+    $endTime = Get-Date
+    if ($enableLogging) {
+        Log-Timing -section $cmd.Description -startTime $startTime -endTime $endTime
+    }
+}
 
 # Uncomment the following line to enable default behaviour of clearing the terminal screen after the profile setup
 # clear

--- a/powershell-profile/profile.ps1
+++ b/powershell-profile/profile.ps1
@@ -1,6 +1,16 @@
 # PowerShell Profile Script
 
-
+# Function to log timing information
+function Log-Timing {
+    param (
+        [string]$section,
+        [datetime]$startTime,
+        [datetime]$endTime
+    )
+    $duration = $endTime - $startTime
+    $logEntry = "$section - Start: $startTime, End: $endTime, Duration: $duration"
+    Add-Content -Path "$PSScriptRoot\profile_timing.log" -Value $logEntry
+}
 
 # Profile Setup
 
@@ -10,21 +20,36 @@ if (-not $env:USERPROFILE) {
     return
 }
 
+# Timing for Chocolatey profile import
+$chocoStartTime = Get-Date
 # Import chocolatey profile so it can run refreshenv command
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+$chocoEndTime = Get-Date
+Log-Timing -section "Chocolatey Profile Import" -startTime $chocoStartTime -endTime $chocoEndTime
 
+# Timing for environment variables refresh
+$envStartTime = Get-Date
 # Refresh environment variables
 refreshenv
+$envEndTime = Get-Date
+Log-Timing -section "Environment Variables Refresh" -startTime $envStartTime -endTime $envEndTime
 
+# Timing for posh-git import
+$poshGitStartTime = Get-Date
 # Import posh-git
 Import-Module posh-git
+$poshGitEndTime = Get-Date
+Log-Timing -section "Posh-Git Import" -startTime $poshGitStartTime -endTime $poshGitEndTime
 
+# Timing for oh-my-posh theme import
+$ompStartTime = Get-Date
 # Import oh-my-posh theme
 oh-my-posh init pwsh --config "$repoPath\oh-my-posh\plenty-of-info.omp.json" | Invoke-Expression
+$ompEndTime = Get-Date
+Log-Timing -section "Oh-My-Posh Theme Import" -startTime $ompStartTime -endTime $ompEndTime
 
 # Uncomment the following line to enable default behaviour of clearing the terminal screen after the profile setup
 # clear
-
 
 # Useful Functions
 


### PR DESCRIPTION
Fixes #16

Add timing and logging functionality to measure the performance of each section in the PowerShell profile script.

* **Profile Script (`powershell-profile/profile.ps1`):**
  - Add `Log-Timing` function to log timing information.
  - Add timing code at the start and end of each major section (Chocolatey profile import, environment variables refresh, posh-git import, oh-my-posh theme import).
  - Log timing information to `profile_timing.log` file.

* **Documentation (`powershell-profile/README.md`):**
  - Update to include information about the new timing and logging feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ScottWilliamAnderson/scripts/pull/17?shareId=884f95ab-11b0-4ec8-8d1a-621168480b6e).