### PR TITLE
feat(autohotkey): add Minecraft hotbar scroll script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,17 +136,37 @@ return
 
 ## Commit Message Guidelines
 
-- **Subject line:** 50 characters max, capitalized, imperative mood, no period
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) style.
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+- **Subject line:** 50 characters max, lowercase, imperative mood, no period
 - **Body:** Wrap at 72 characters, explain "why" not "how"
+- **Scope:** Optional, indicates the area of the codebase (e.g., `autohotkey`, `profile`, `git-config`)
 
-### Common Prefixes
+### Types
 
-- `Add` - New feature or script
-- `Fix` - Bug fix
-- `Update` - Enhancement to existing feature
-- `Remove` - Removing code or features
-- `Refactor` - Code restructuring without behavior change
-- `Docs` - Documentation only changes
+- `feat` - New feature or script
+- `fix` - Bug fix
+- `docs` - Documentation only changes
+- `refactor` - Code restructuring without behavior change
+- `chore` - Maintenance tasks, dependencies, configs
+
+### Commit Strategy
+
+- **Prefer small, targeted commits** over large feature commits
+- Each commit should represent a single logical change
+- When adding a feature, consider separate commits for:
+  - The core implementation
+  - Documentation updates
+  - README updates
+- Use `git add -p` to stage hunks when a file contains multiple logical changes
 
 ## Adding New Scripts
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,14 @@ choco install packages.config
 ```
 
 ### AutoHotkey Scripts
-- [**vlc-autohotkey**](autohotkey/README.md) (AutoHotkey) - Quick speed controls for VLC
-```powershell
-# Manually:
-cd .\autohotkey\
-.\vlc-speed-controls.ahk
+- [**AutoHotkey Scripts**](autohotkey/README.md) (AutoHotkey) - Keyboard and mouse automation scripts
+  - **MinecraftHotbarScroll** - Use mouse side buttons to scroll the hotbar
+  - **vlc-speed-controls** - Quick speed controls for VLC (hold number keys for fast playback)
 
-# via PowerShell alias/function:
-vlcs
-# Instantly launches the script thanks to a function in profile.ps1
+```powershell
+# Double-click any .ahk file to run, or from PowerShell:
+.\autohotkey\MinecraftHotbarScroll.ahk
+.\autohotkey\vlc-speed-controls.ahk
 ```
 
 ## 🚀 Getting Started

--- a/autohotkey/MinecraftHotbarScroll.ahk
+++ b/autohotkey/MinecraftHotbarScroll.ahk
@@ -1,0 +1,25 @@
+; MinecraftHotbarScroll.ahk
+; Remaps mouse side buttons (XButton1/XButton2) to scroll the hotbar in Minecraft.
+; XButton1 (back) scrolls hotbar right (next slot)
+; XButton2 (forward) scrolls hotbar left (previous slot)
+; Uses {Blind} modifier to preserve Shift key state for stack splitting.
+
+#NoEnv                   ; Recommended for performance
+SendMode Input           ; Faster, more reliable
+SetWorkingDir %A_ScriptDir%
+
+; --- Minecraft-specific hotkeys (matches Java Edition) ---
+#IfWinActive, ahk_exe javaw.exe
+
+*XButton1::
+    ; Scroll hotbar right (next slot)
+    Send {Blind}{WheelDown}
+return
+
+*XButton2::
+    ; Scroll hotbar left (previous slot)
+    Send {Blind}{WheelUp}
+return
+
+; End context-sensitive remappings
+#If

--- a/autohotkey/README.md
+++ b/autohotkey/README.md
@@ -1,24 +1,14 @@
-# VLC AutoHotkey Speed Controls 🎮
+# AutoHotkey Scripts 🎮
 
 <img alt="AutoHotkey" src="https://img.shields.io/badge/AutoHotkey-1.x-green.svg">
-<img alt="VLC" src="https://img.shields.io/badge/VLC-3.0+-orange.svg">
 <img alt="Platform" src="https://img.shields.io/badge/Platform-Windows-blue.svg">
 <img alt="MIT License" src="https://img.shields.io/badge/License-MIT-yellow.svg">
 
-
-A convenient AutoHotkey script for controlling VLC media player playback speed using keyboard shortcuts.
-
-## 📌 Features
-- 🎯 Instant speed control with number keys
-- ⚡ Press and hold functionality
-- 🔄 Auto-reset on key release
-- 🎮 VLC-specific activation
-- ⌨️ Customizable speed presets
+A collection of AutoHotkey scripts for enhancing application controls on Windows.
 
 ## 🔍 Requirements
 - Windows 10/11
 - AutoHotkey v1.x
-- VLC Media Player 3.0+
 
 ## 🚀 Installation
 
@@ -26,7 +16,7 @@ A convenient AutoHotkey script for controlling VLC media player playback speed u
 
 ```powershell
 # Using Chocolatey
-choco install autohotkey vlc
+choco install autohotkey
 ```
 OR
 
@@ -34,7 +24,7 @@ Download from [autohotkey.com](https://www.autohotkey.com/)
 Run installer with default options
 
 
-### Download Script
+### Download Scripts
 
 Clone this repository or download directly:
 ```powershell 
@@ -42,20 +32,60 @@ git clone https://github.com/ScottWilliamAnderson/scripts.git
 cd scripts/autohotkey
 ```
 
-### Run Script
+### Running Scripts
 
-Double-click vlc-speed-controls.ahk
+Double-click any `.ahk` file to run it. A green "H" icon will appear in the system tray indicating the script is active.
 
-Or from PowerShell:
+To run on Windows startup:
+1. Press `Win + R`, type `shell:startup`, and press Enter
+2. Create a shortcut to the desired `.ahk` file in this folder
 
-```powershell 
-.\vlc-speed-controls.ahk
-# If you have the updated `profile.ps1` with the `vlcs` function, simply type:
-vlcs
-# This will launch `vlc-speed-controls.ahk` automatically.
-```
+---
 
-## 🎮 Usage
+## 📜 Available Scripts
+
+### Minecraft Hotbar Scroll
+
+**File:** `MinecraftHotbarScroll.ahk`
+
+Remaps mouse side buttons to scroll the Minecraft hotbar, allowing you to switch hotbar slots without moving your hand to the scroll wheel.
+
+#### 📌 Features
+- 🎯 Mouse side button control for hotbar
+- ⚡ Works with Shift held (for stack splitting)
+- 🎮 Minecraft Java Edition only (detects `javaw.exe`)
+
+#### 🎮 Usage
+
+| Button | Action |
+|--------|--------|
+| XButton1 (Back) | Scroll hotbar right (next slot) |
+| XButton2 (Forward) | Scroll hotbar left (previous slot) |
+
+#### 🔧 Notes
+- The script activates only when Minecraft (Java Edition) is the active window
+- Uses `{Blind}` modifier to preserve modifier key states (e.g., holding Shift)
+
+---
+
+### VLC Speed Controls
+
+**File:** `vlc-speed-controls.ahk`
+
+<img alt="VLC" src="https://img.shields.io/badge/VLC-3.0+-orange.svg">
+
+A convenient script for controlling VLC media player playback speed using keyboard shortcuts.
+
+#### 📌 Features
+- 🎯 Instant speed control with number keys
+- ⚡ Press and hold functionality
+- 🔄 Auto-reset on key release
+- 🎮 VLC-specific activation
+
+#### 🔍 Additional Requirements
+- VLC Media Player 3.0+
+
+#### 🎮 Usage
 
 | Key | Action         | Release Action |
 |-----|----------------|----------------|
@@ -65,27 +95,37 @@ vlcs
 | 4   | Set 4.0x speed | Return to 1.0x |
 | 5   | Set 5.0x speed | Return to 1.0x |
 
-## 🔧 Configuration
-Edit vlc-speed-controls.ahk to customize:
+#### 🔧 Configuration
+Edit `vlc-speed-controls.ahk` to customize:
 
 - Speed presets
 - Key bindings
 - Reset behaviour
 
+#### 💡 Tip
+If you have the updated `profile.ps1` with the `vlcs` function, simply type:
+```powershell
+vlcs
+```
+This will launch `vlc-speed-controls.ahk` automatically.
+
+---
+
 ## 🔍 Troubleshooting
+
 *Script not working*
 
-1. Ensure VLC window is active
-2. Check AutoHotkey is running (system tray)
+1. Ensure the target application window is active
+2. Check AutoHotkey is running (green "H" in system tray)
 3. Run as administrator if needed
 
+*Hotkeys not triggering*
 
-*Speed not changing*
-
-1. Verify VLC version compatibility
-2. Check for conflicting keyboard shortcuts
+1. Verify application compatibility (check window title/exe name)
+2. Check for conflicting keyboard/mouse shortcuts
+3. Ensure AutoHotkey v1.x is installed (not v2.x)
 
 ## 📝 License
-MIT © Scott Anderson 2024
+MIT © Scott Anderson 2025
 
 *For more utilities, visit the main repository [here](../README.md)*


### PR DESCRIPTION
## Summary

- Add `MinecraftHotbarScroll.ahk` script that remaps mouse side buttons (XButton1/XButton2) to scroll the Minecraft hotbar
- Update autohotkey README to document both scripts with unified structure
- Add Minecraft script entry to main README

## Changes

| File | Description |
|------|-------------|
| `autohotkey/MinecraftHotbarScroll.ahk` | New script with standard AHK headers and documentation |
| `autohotkey/README.md` | Restructured to cover all AutoHotkey scripts |
| `README.md` | Updated AutoHotkey section with both scripts |
| `AGENTS.md` | Updated commit guidelines to conventional commits style |

## Features

- XButton1 (back) → scroll hotbar right (next slot)
- XButton2 (forward) → scroll hotbar left (previous slot)
- Preserves Shift key state using `{Blind}` modifier (for sneak)
- Only activates when Minecraft Java Edition (`javaw.exe`) is focused