### PR TITLE
Feature/notify alias (#32)

### DIFF
--- a/chocolatey/packages.config
+++ b/chocolatey/packages.config
@@ -5,6 +5,7 @@
   <package id="autohotkey" />
   <package id="bleachbit" />
   <package id="bleachbit.install" />
+  <package id="burnttoast-psmodule" />
   <package id="chocolatey" />
   <package id="chocolatey-compatibility.extension" />
   <package id="chocolatey-core.extension" />

--- a/chocolatey/packages.config
+++ b/chocolatey/packages.config
@@ -5,7 +5,6 @@
   <package id="autohotkey" />
   <package id="bleachbit" />
   <package id="bleachbit.install" />
-  <package id="burnttoast-psmodule" />
   <package id="chocolatey" />
   <package id="chocolatey-compatibility.extension" />
   <package id="chocolatey-core.extension" />
@@ -54,6 +53,9 @@
   <package id="yt-dlp" />
 
   <!-- Packages / Programs not installed via choco -->
+
+  <!-- BurntToast (PowerShell module for toast notifications)
+  Install-Module -Name BurntToast -Scope CurrentUser -->
   
   <!-- Battery Mode 64 Bit 
   https://en.bmode.tarcode.ru/download -->

--- a/powershell-profile/README.md
+++ b/powershell-profile/README.md
@@ -22,6 +22,7 @@ This guide will help you set up your PowerShell profile to import a custom profi
 - ⏱️ Timing and logging for performance measurement
 - 🤖 GitHub Copilot CLI integration
 - 🔐 GPG agent auto-start for commit signing
+- 🔔 Toast notifications with BurntToast (`notify` and `remind-me`)
 
 ## 🔍 Requirements
 
@@ -30,6 +31,7 @@ This guide will help you set up your PowerShell profile to import a custom profi
 - Oh My Posh installed
 - Chocolatey installed
 - Posh-Git installed
+- BurntToast installed (for toast notifications)
 
 ### Optional Requirements
 
@@ -110,6 +112,8 @@ This guide will help you set up your PowerShell profile to import a custom profi
 | `copilot-setup` | Configures GitHub Copilot CLI to use `ghcs` and `ghce` aliases |
 | `start-gpg-agent` | Starts the GPG agent if GPG signing is configured |
 | `vlcs`   | Quickly activates the VLC speedup AutoHotkey script (`vlc-speed-controls.ahk`) from anywhere |
+| `notify` | Displays a Windows toast notification using BurntToast |
+| `remind-me` | Sets a timer-based reminder notification (e.g., `remind-me 5m "Take a break"`) |
 
 ## ⏱️ Startup Performance
 

--- a/powershell-profile/README.md
+++ b/powershell-profile/README.md
@@ -31,7 +31,7 @@ This guide will help you set up your PowerShell profile to import a custom profi
 - Oh My Posh installed
 - Chocolatey installed
 - Posh-Git installed
-- BurntToast installed (for toast notifications)
+- [BurntToast](https://github.com/Windos/BurntToast) installed
 
 ### Optional Requirements
 


### PR DESCRIPTION
This pull request adds support for toast notifications in the PowerShell profile using the BurntToast module. It introduces two new functions, `notify` and `remind-me`, for sending notifications and reminders, and updates documentation and configuration to reflect these changes.

Closes #32 32

**PowerShell notification enhancements:**

* Added a new `notify` function to `profile.ps1` for displaying customizable Windows toast notifications via BurntToast, with support for sound, urgency, and custom images.
* Added a new `remind-me` function to `profile.ps1` for setting timer-based reminder notifications, supporting time formats and optional snooze/dismiss actions.

**Documentation updates:**

* Updated `README.md` to document the new `notify` and `remind-me` commands, including usage examples and descriptions.
* Added BurntToast as a required dependency in the `README.md` and provided an installation link.
* Noted BurntToast installation instructions in `packages.config` as a comment for user guidance.
* Listed toast notification support in the feature summary of `README.md`.This pull request adds toast notification capabilities to the PowerShell profile using the BurntToast module. It introduces two new functions, `notify` and `remind-me`, which allow users to display custom notifications and set timer-based reminders. The documentation has been updated to reflect these new features and their requirements, and the `burnttoast-psmodule` package has been added as a dependency.

**PowerShell Profile Enhancements:**

* Added a `notify` function to `profile.ps1` for displaying Windows toast notifications with customizable options such as title, sound, urgency, and image.
* Added a `remind-me` function to `profile.ps1` to schedule timer-based reminder notifications using BurntToast, supporting delays in seconds, minutes, or hours.

Closes: https://github.com/ScottWilliamAnderson/scripts/issues/32

**Documentation Updates:**

* Updated the feature list in `README.md` to include toast notifications and the new `notify` and `remind-me` commands. [[1]](diffhunk://#diff-ad428fe6fdd5391de700a6e9fa36f4010aae728d66bac4be7575b71fca7fc0f3R25) [[2]](diffhunk://#diff-ad428fe6fdd5391de700a6e9fa36f4010aae728d66bac4be7575b71fca7fc0f3R115-R116)
* Added BurntToast as a requirement in the `README.md`.

**Dependencies:**

* Added the `burnttoast-psmodule` package to `chocolatey/packages.config` to ensure BurntToast is installed.